### PR TITLE
v0.5: Observability — admin HTTP API with Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,58 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -242,10 +300,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -302,6 +402,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +497,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -364,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +571,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -445,9 +644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pgvpd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
+ "axum",
  "base64",
  "bytes",
  "clap",
@@ -458,6 +664,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde",
+ "serde_json",
  "sha2",
  "tokio",
  "tokio-rustls",
@@ -472,6 +679,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -622,6 +835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,11 +877,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -703,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +1001,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thread_local"
@@ -830,11 +1097,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1161,3 +1457,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgvpd"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Virtual Private Database for PostgreSQL — tenant isolation at the connection level"
 license = "MIT"
@@ -22,4 +22,6 @@ base64 = "0.22"
 md-5 = "0.10"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
+axum = "0.8"

--- a/pgvpd.conf.example
+++ b/pgvpd.conf.example
@@ -117,6 +117,13 @@
 # Seconds to wait for a connection when the pool is full.
 # pool_checkout_timeout = 5
 
+# ─── Admin API ──────────────────────────────────────────────
+#
+# HTTP port for the admin API (health, metrics, pool status).
+# Disabled by default. Enable for load balancer health checks
+# and Prometheus metrics scraping.
+# admin_port = 9090
+
 # ─── Logging ─────────────────────────────────────────────────
 
 # Log level: debug, info, warn, error

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,233 @@
+//! Admin HTTP API — health checks, Prometheus metrics, pool/resolver status.
+//!
+//! Spawned as a background task when `admin_port` is configured.
+//! Endpoints:
+//!   GET /health  — 200 OK, for load balancer health checks
+//!   GET /metrics — Prometheus exposition format
+//!   GET /status  — JSON snapshot of pool and resolver state
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tracing::{error, info};
+
+use crate::metrics::Metrics;
+use crate::pool::Pool;
+use crate::resolver::ResolverEngine;
+
+/// Shared state for admin endpoints.
+#[derive(Clone)]
+pub struct AdminState {
+    pub metrics: Arc<Metrics>,
+    pub pool: Option<Arc<Pool>>,
+    pub resolver: Option<Arc<ResolverEngine>>,
+}
+
+/// Start the admin HTTP server on the given port.
+pub async fn serve(state: AdminState, port: u16) {
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/metrics", get(metrics))
+        .route("/status", get(status))
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{port}");
+    match TcpListener::bind(&addr).await {
+        Ok(listener) => {
+            info!(addr = %addr, "admin API");
+            if let Err(e) = axum::serve(listener, app).await {
+                error!(error = %e, "admin server error");
+            }
+        }
+        Err(e) => {
+            error!(addr = %addr, error = %e, "failed to bind admin port");
+        }
+    }
+}
+
+// ─── GET /health ─────────────────────────────────────────────────────────────
+
+async fn health() -> impl IntoResponse {
+    (StatusCode::OK, [("content-type", "application/json")], r#"{"status":"ok"}"#)
+}
+
+// ─── GET /metrics ────────────────────────────────────────────────────────────
+
+async fn metrics(State(state): State<AdminState>) -> Response {
+    let m = &state.metrics;
+    let mut out = String::with_capacity(2048);
+
+    // Connection metrics
+    out.push_str("# HELP pgvpd_connections_total Total connections accepted.\n");
+    out.push_str("# TYPE pgvpd_connections_total counter\n");
+    push_metric(&mut out, "pgvpd_connections_total", "", m.connections_total.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_connections_active Currently active connections.\n");
+    out.push_str("# TYPE pgvpd_connections_active gauge\n");
+    push_metric(&mut out, "pgvpd_connections_active", "", m.connections_active.load(Ordering::Relaxed));
+
+    // Pool metrics (per bucket from snapshot)
+    if let Some(pool) = &state.pool {
+        let snap = pool.snapshot().await;
+        out.push_str("# HELP pgvpd_pool_connections_total Total connections in pool bucket.\n");
+        out.push_str("# TYPE pgvpd_pool_connections_total gauge\n");
+        out.push_str("# HELP pgvpd_pool_connections_idle Idle connections in pool bucket.\n");
+        out.push_str("# TYPE pgvpd_pool_connections_idle gauge\n");
+        for b in &snap.buckets {
+            let labels = format!(r#"database="{}",role="{}""#, b.database, b.role);
+            push_metric(&mut out, "pgvpd_pool_connections_total", &labels, b.total as u64);
+            push_metric(&mut out, "pgvpd_pool_connections_idle", &labels, b.idle as u64);
+        }
+    }
+
+    out.push_str("# HELP pgvpd_pool_checkouts_total Total pool checkouts.\n");
+    out.push_str("# TYPE pgvpd_pool_checkouts_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_checkouts_total", "", m.pool_checkouts.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_pool_reuses_total Pool connections reused from idle.\n");
+    out.push_str("# TYPE pgvpd_pool_reuses_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_reuses_total", "", m.pool_reuses.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_pool_creates_total New pool connections created.\n");
+    out.push_str("# TYPE pgvpd_pool_creates_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_creates_total", "", m.pool_creates.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_pool_checkins_total Pool connections returned.\n");
+    out.push_str("# TYPE pgvpd_pool_checkins_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_checkins_total", "", m.pool_checkins.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_pool_discards_total Pool connections discarded on checkin failure.\n");
+    out.push_str("# TYPE pgvpd_pool_discards_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_discards_total", "", m.pool_discards.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_pool_timeouts_total Pool checkout timeouts.\n");
+    out.push_str("# TYPE pgvpd_pool_timeouts_total counter\n");
+    push_metric(&mut out, "pgvpd_pool_timeouts_total", "", m.pool_timeouts.load(Ordering::Relaxed));
+
+    // Resolver metrics
+    if let Some(resolver) = &state.resolver {
+        let cache_size = resolver.cache_size().await;
+        out.push_str("# HELP pgvpd_resolver_cache_size Current resolver cache entries.\n");
+        out.push_str("# TYPE pgvpd_resolver_cache_size gauge\n");
+        push_metric(&mut out, "pgvpd_resolver_cache_size", "", cache_size as u64);
+    }
+
+    out.push_str("# HELP pgvpd_resolver_cache_hits_total Resolver cache hits.\n");
+    out.push_str("# TYPE pgvpd_resolver_cache_hits_total counter\n");
+    push_metric(&mut out, "pgvpd_resolver_cache_hits_total", "", m.resolver_cache_hits.load(Ordering::Relaxed));
+    out.push_str("# HELP pgvpd_resolver_cache_misses_total Resolver cache misses.\n");
+    out.push_str("# TYPE pgvpd_resolver_cache_misses_total counter\n");
+    push_metric(&mut out, "pgvpd_resolver_cache_misses_total", "", m.resolver_cache_misses.load(Ordering::Relaxed));
+
+    if !m.resolver_names.is_empty() {
+        out.push_str("# HELP pgvpd_resolver_executions_total Resolver executions.\n");
+        out.push_str("# TYPE pgvpd_resolver_executions_total counter\n");
+        for (i, name) in m.resolver_names.iter().enumerate() {
+            let labels = format!(r#"resolver="{}""#, name);
+            if let Some(counter) = m.resolver_executions.get(i) {
+                push_metric(&mut out, "pgvpd_resolver_executions_total", &labels, counter.load(Ordering::Relaxed));
+            }
+        }
+        out.push_str("# HELP pgvpd_resolver_errors_total Resolver errors.\n");
+        out.push_str("# TYPE pgvpd_resolver_errors_total counter\n");
+        for (i, name) in m.resolver_names.iter().enumerate() {
+            let labels = format!(r#"resolver="{}""#, name);
+            if let Some(counter) = m.resolver_errors.get(i) {
+                push_metric(&mut out, "pgvpd_resolver_errors_total", &labels, counter.load(Ordering::Relaxed));
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+        out,
+    ).into_response()
+}
+
+fn push_metric(out: &mut String, name: &str, labels: &str, value: u64) {
+    if labels.is_empty() {
+        out.push_str(&format!("{name} {value}\n"));
+    } else {
+        out.push_str(&format!("{name}{{{labels}}} {value}\n"));
+    }
+}
+
+// ─── GET /status ─────────────────────────────────────────────────────────────
+
+async fn status(State(state): State<AdminState>) -> Response {
+    let m = &state.metrics;
+
+    let mut json = String::with_capacity(1024);
+    json.push_str("{\n");
+
+    // Connections
+    json.push_str(&format!(
+        "  \"connections_total\": {},\n  \"connections_active\": {},\n",
+        m.connections_total.load(Ordering::Relaxed),
+        m.connections_active.load(Ordering::Relaxed),
+    ));
+
+    // Pool
+    json.push_str("  \"pool\": {\n");
+    json.push_str(&format!("    \"checkouts\": {},\n", m.pool_checkouts.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"reuses\": {},\n", m.pool_reuses.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"creates\": {},\n", m.pool_creates.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"checkins\": {},\n", m.pool_checkins.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"discards\": {},\n", m.pool_discards.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"timeouts\": {},\n", m.pool_timeouts.load(Ordering::Relaxed)));
+
+    json.push_str("    \"buckets\": [");
+    if let Some(pool) = &state.pool {
+        let snap = pool.snapshot().await;
+        for (i, b) in snap.buckets.iter().enumerate() {
+            if i > 0 { json.push(','); }
+            json.push_str(&format!(
+                "\n      {{\"database\": \"{}\", \"role\": \"{}\", \"total\": {}, \"idle\": {}}}",
+                b.database, b.role, b.total, b.idle
+            ));
+        }
+        if !snap.buckets.is_empty() {
+            json.push('\n');
+            json.push_str("    ");
+        }
+    }
+    json.push_str("]\n");
+    json.push_str("  },\n");
+
+    // Resolvers
+    json.push_str("  \"resolvers\": {\n");
+    json.push_str(&format!("    \"cache_hits\": {},\n", m.resolver_cache_hits.load(Ordering::Relaxed)));
+    json.push_str(&format!("    \"cache_misses\": {},\n", m.resolver_cache_misses.load(Ordering::Relaxed)));
+
+    if let Some(resolver) = &state.resolver {
+        let cache_size = resolver.cache_size().await;
+        json.push_str(&format!("    \"cache_size\": {},\n", cache_size));
+    } else {
+        json.push_str("    \"cache_size\": 0,\n");
+    }
+
+    json.push_str("    \"resolvers\": [");
+    for (i, name) in m.resolver_names.iter().enumerate() {
+        if i > 0 { json.push(','); }
+        let execs = m.resolver_executions.get(i).map(|c| c.load(Ordering::Relaxed)).unwrap_or(0);
+        let errs = m.resolver_errors.get(i).map(|c| c.load(Ordering::Relaxed)).unwrap_or(0);
+        json.push_str(&format!(
+            "\n      {{\"name\": \"{}\", \"executions\": {}, \"errors\": {}}}",
+            name, execs, errs
+        ));
+    }
+    if !m.resolver_names.is_empty() {
+        json.push('\n');
+        json.push_str("    ");
+    }
+    json.push_str("]\n");
+    json.push_str("  }\n");
+
+    json.push_str("}\n");
+
+    (
+        StatusCode::OK,
+        [("content-type", "application/json")],
+        json,
+    ).into_response()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,10 @@ pub struct Cli {
     /// Path to context resolver TOML file
     #[arg(long)]
     pub resolvers: Option<String>,
+
+    /// HTTP port for admin API (health, metrics, status)
+    #[arg(long)]
+    pub admin_port: Option<u16>,
 }
 
 #[derive(Debug, Clone)]
@@ -149,6 +153,7 @@ pub struct Config {
     pub pool_idle_timeout: u64,
     pub pool_checkout_timeout: u64,
     pub resolvers: Option<String>,
+    pub admin_port: Option<u16>,
 }
 
 impl Default for Config {
@@ -177,6 +182,7 @@ impl Default for Config {
             pool_idle_timeout: 300,
             pool_checkout_timeout: 5,
             resolvers: None,
+            admin_port: None,
         }
     }
 }
@@ -267,6 +273,9 @@ impl Config {
         }
         if let Some(v) = cli.resolvers {
             config.resolvers = Some(v);
+        }
+        if let Some(v) = cli.admin_port {
+            config.admin_port = Some(v);
         }
 
         config
@@ -387,6 +396,11 @@ fn apply_config_file(config: &mut Config, content: &str) {
                 }
             }
             "resolvers" => config.resolvers = Some(value),
+            "admin_port" => {
+                if let Ok(v) = value.parse() {
+                    config.admin_port = Some(v);
+                }
+            }
             _ => {}
         }
     }
@@ -475,6 +489,11 @@ fn apply_env(config: &mut Config) {
     }
     if let Ok(v) = std::env::var("PGVPD_RESOLVERS") {
         config.resolvers = Some(v);
+    }
+    if let Ok(v) = std::env::var("PGVPD_ADMIN_PORT") {
+        if let Ok(p) = v.parse() {
+            config.admin_port = Some(p);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+mod admin;
 mod auth;
 mod config;
 mod connection;
+mod metrics;
 mod pool;
 mod protocol;
 mod resolver;
@@ -12,7 +14,7 @@ use tracing_subscriber::EnvFilter;
 
 const BANNER: &str = r#"
   ╔══════════════════════════════════════════════════╗
-  ║                  P G V P D  v0.4                 ║
+  ║                  P G V P D  v0.5                 ║
   ║      Virtual Private Database for PostgreSQL     ║
   ║                    [ Rust ]                      ║
   ╚══════════════════════════════════════════════════╝

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,66 @@
+//! Shared metrics — atomic counters for observability.
+//!
+//! Wrapped in `Arc<Metrics>` and passed to pool, resolver, and connection handler.
+//! No external crate needed — we format Prometheus exposition text manually.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Shared metrics counters, all lock-free via AtomicU64.
+pub struct Metrics {
+    // ─── Connections ─────────────────────────────────────────────────────
+    pub connections_total: AtomicU64,
+    pub connections_active: AtomicU64,
+
+    // ─── Pool ────────────────────────────────────────────────────────────
+    pub pool_checkouts: AtomicU64,
+    pub pool_reuses: AtomicU64,
+    pub pool_creates: AtomicU64,
+    pub pool_checkins: AtomicU64,
+    pub pool_discards: AtomicU64,
+    pub pool_timeouts: AtomicU64,
+
+    // ─── Resolvers ───────────────────────────────────────────────────────
+    pub resolver_cache_hits: AtomicU64,
+    pub resolver_cache_misses: AtomicU64,
+    /// Per-resolver execution counts (indexed by resolver order).
+    pub resolver_executions: Vec<AtomicU64>,
+    /// Per-resolver error counts (indexed by resolver order).
+    pub resolver_errors: Vec<AtomicU64>,
+    /// Resolver names for label rendering (indexed by resolver order).
+    pub resolver_names: Vec<String>,
+}
+
+impl Metrics {
+    /// Create a new Metrics instance with zeroed counters.
+    /// `resolver_names` determines the size of per-resolver vectors.
+    pub fn new(resolver_names: Vec<String>) -> Self {
+        let n = resolver_names.len();
+        Self {
+            connections_total: AtomicU64::new(0),
+            connections_active: AtomicU64::new(0),
+            pool_checkouts: AtomicU64::new(0),
+            pool_reuses: AtomicU64::new(0),
+            pool_creates: AtomicU64::new(0),
+            pool_checkins: AtomicU64::new(0),
+            pool_discards: AtomicU64::new(0),
+            pool_timeouts: AtomicU64::new(0),
+            resolver_cache_hits: AtomicU64::new(0),
+            resolver_cache_misses: AtomicU64::new(0),
+            resolver_executions: (0..n).map(|_| AtomicU64::new(0)).collect(),
+            resolver_errors: (0..n).map(|_| AtomicU64::new(0)).collect(),
+            resolver_names,
+        }
+    }
+
+    /// Increment a counter by 1 and return the previous value.
+    #[inline]
+    pub fn inc(counter: &AtomicU64) -> u64 {
+        counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Decrement a counter by 1 (saturating).
+    #[inline]
+    pub fn dec(counter: &AtomicU64) {
+        counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}

--- a/tests/pgvpd-admin-test.conf
+++ b/tests/pgvpd-admin-test.conf
@@ -1,0 +1,12 @@
+# Admin API test config (pool mode + admin)
+port = 16432
+upstream_host = 127.0.0.1
+upstream_port = 15432
+context_variables = app.current_tenant_id
+superuser_bypass = postgres
+log_level = debug
+pool_mode = session
+pool_size = 3
+pool_password = testpass
+upstream_password = testpass
+admin_port = 19090


### PR DESCRIPTION
## Summary

- **Admin HTTP API** (axum) on configurable `admin_port` with `/health`, `/metrics` (Prometheus), and `/status` (JSON) endpoints
- **Shared metrics** (`Arc<Metrics>` with `AtomicU64` counters) wired into pool and resolver engine
- **Doc updates**: PLAN.md, README.md, and docs/architecture.md now cover connection pooling, context resolvers, TLS, `pipe_pooled`, two-step checkin, and the full component map

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo test` — 11 unit tests pass
- [x] `./tests/run.sh` — 17/17 integration tests pass (4 new admin API tests)
- [ ] Manual: start pgvpd with `admin_port = 9090`, verify `curl localhost:9090/health`, `/metrics`, `/status`